### PR TITLE
#36 add option to reset parent config for link objects

### DIFF
--- a/arondor-common-reflection-gwt/src/main/java/com/arondor/common/reflection/gwt/client/AccessibleClassPresenterFactory.java
+++ b/arondor-common-reflection-gwt/src/main/java/com/arondor/common/reflection/gwt/client/AccessibleClassPresenterFactory.java
@@ -59,8 +59,9 @@ public class AccessibleClassPresenterFactory
     public static AccessibleClassPresenter createAccessibleClassPresenter(GWTReflectionServiceAsync rpcService,
             ObjectReferencesProvider objectReferencesProvider, String baseClassName)
     {
+        boolean isLink = baseClassName.equals("com.fast2.model.taskflow.design.TaskLinkCondition");
         return new HierarchicAccessibleClassPresenter(rpcService, objectReferencesProvider, baseClassName,
-                FACTORY.createClassDisplay());
+                FACTORY.createClassDisplay(isLink));
     }
 
     public static ObjectConfigurationMapPresenter createObjectConfigurationMapPresenter(

--- a/arondor-common-reflection-gwt/src/main/java/com/arondor/common/reflection/gwt/client/nview/NClassTreeView.java
+++ b/arondor-common-reflection-gwt/src/main/java/com/arondor/common/reflection/gwt/client/nview/NClassTreeView.java
@@ -11,11 +11,17 @@ public class NClassTreeView extends FlowPanel
 {
     private final NClassNodeView rootView = new NClassNodeView();
 
-    public NClassTreeView()
+    public NClassTreeView(boolean isLink)
     {
-        rootView.disableReset();
+        if (!isLink)
+            rootView.disableReset();
         getElement().addClassName(CssBundle.INSTANCE.css().rootTreeNode());
         add(rootView);
+    }
+
+    public NClassTreeView()
+    {
+        this(false);
     }
 
     @Override

--- a/arondor-common-reflection-gwt/src/main/java/com/arondor/common/reflection/gwt/client/nview/NViewFactory.java
+++ b/arondor-common-reflection-gwt/src/main/java/com/arondor/common/reflection/gwt/client/nview/NViewFactory.java
@@ -7,9 +7,8 @@ public class NViewFactory implements ViewFactory
 {
 
     @Override
-    public HierarchicAccessibleClassPresenter.Display createClassDisplay()
+    public HierarchicAccessibleClassPresenter.Display createClassDisplay(boolean isLink)
     {
-        return new NClassTreeView();
+        return new NClassTreeView(isLink);
     }
-
 }

--- a/arondor-common-reflection-gwt/src/main/java/com/arondor/common/reflection/gwt/client/presenter/ViewFactory.java
+++ b/arondor-common-reflection-gwt/src/main/java/com/arondor/common/reflection/gwt/client/presenter/ViewFactory.java
@@ -2,5 +2,5 @@ package com.arondor.common.reflection.gwt.client.presenter;
 
 public interface ViewFactory
 {
-    HierarchicAccessibleClassPresenter.Display createClassDisplay();
+    HierarchicAccessibleClassPresenter.Display createClassDisplay(boolean isLink);
 }


### PR DESCRIPTION
Link evaluation relies on a static String, which may not be as ideal as it should.